### PR TITLE
Fix/favorite item design qa

### DIFF
--- a/src/pages/FavoriteItem.css
+++ b/src/pages/FavoriteItem.css
@@ -129,3 +129,7 @@
     width: 24px;
     height: 24px;
   }
+
+.hidden {
+    display: none;
+}

--- a/src/pages/FavoriteItem.jsx
+++ b/src/pages/FavoriteItem.jsx
@@ -62,7 +62,7 @@ function CreatePlaylistForm({ onCloseModal }) {
 
   return (
     <div className="p-6 text-neutral-100">
-      <h2 className="text-h6 text-neutral-100 mb-xl">建立新播放清單</h2>
+      <h2 className="text-h6 text-neutral-100 mb-m">建立新播放清單</h2>
       <div className="input-container">
         <input 
           type="text" 

--- a/src/pages/FavoriteItem.jsx
+++ b/src/pages/FavoriteItem.jsx
@@ -80,7 +80,7 @@ function CreatePlaylistForm({ onCloseModal }) {
       </div>
       <div className="gap-m flex">
         <Button otherClass="flex-1 bg-neutral-100 py-xs py-md-s pill-rounded" onClick={onCloseModal}>取消</Button>
-        <Button otherClass={`flex-1 bg-neutral-100 py-xs py-md-s pill-rounded btn-create ${(isFocused || hasValue) ? 'activate' : ''}`} onClick={handleSubmit} >建立</Button>
+        <Button otherClass={`flex-1 bg-neutral-100 py-xs py-md-s pill-rounded btn-create ${(isFocused || hasValue) ? 'activate' : 'bg-neutral-400 text-neutral-900'}`} onClick={handleSubmit} isDisabled={!playlistName.trim()}>建立</Button>
       </div>
     </div>
   );

--- a/src/pages/FavoriteItem.jsx
+++ b/src/pages/FavoriteItem.jsx
@@ -145,6 +145,7 @@ function FavoriteItem() {
                           name="playlist-menu"
                           styledModalCustomClass="bottom-sheet"
                           needCloseBtn={false}
+                          showOverlay={false}
                         >
                             <PlaylistMenu></PlaylistMenu>
                         </Modal.Window>

--- a/src/ui/Modal.jsx
+++ b/src/ui/Modal.jsx
@@ -39,6 +39,7 @@ function Window({
   needCloseBtn = true,
   overlayCustomClass,
   styledModalCustomClass,
+  showOverlay = true,
 }) {
   const { openName, close } = useContext(ModalContext);
   const ref = useOutsideClick(close);
@@ -46,19 +47,31 @@ function Window({
   if (name !== openName) return null;
 
   return createPortal(
-    <Overlay overlayCustomClass={overlayCustomClass}>
+    showOverlay ? (
+      <Overlay overlayCustomClass={overlayCustomClass}>
+        <StyledModal ref={ref} styledModalCustomClass={styledModalCustomClass}>
+          {needCloseBtn && (
+            <Button onClick={close}>
+              <span className="material-symbols-rounded absolute close-btn-position text-neural-100">
+                close
+              </span>
+            </Button>
+          )}
+          <div>{cloneElement(children, { onCloseModal: close })}</div>
+        </StyledModal>
+      </Overlay>
+    ) : (
       <StyledModal ref={ref} styledModalCustomClass={styledModalCustomClass}>
         {needCloseBtn && (
           <Button onClick={close}>
-            <span className="material-symbols-rounded absolute close-btn-position text-neutral-100">
+            <span className="material-symbols-rounded absolute close-btn-position text-neural-100">
               close
             </span>
           </Button>
         )}
-
         <div>{cloneElement(children, { onCloseModal: close })}</div>
       </StyledModal>
-    </Overlay>,
+    ),
     document.body
   );
 }


### PR DESCRIPTION
## 修復：收藏片單頁面設計 QA 調整

### 概述
此 PR 針對收藏片單頁面進行設計 QA 調整，主要改善 Modal 功能和用戶體驗。

### 主要變更

#### Modal 組件功能增強
- **新增 `showOverlay` 參數** 讓 Modal 組件可以控制是否顯示背景遮罩
- 根據使用情境靈活控制 Modal 的顯示方式

#### 收藏片單頁面改善
- **建立播放清單按鈕的自定義禁用樣式**
- 按鈕在禁用狀態時顯示適當的視覺回饋（灰色背景、降低透明度）
- **Modal 標題間距調整** - 將下邊距調整為 16px 以改善視覺對齊

#### UI/UX 改善
- 播放清單選單 Modal 採用底部彈出樣式
- 改善按鈕狀態和視覺層次
- 播放清單建立表單的驗證回饋更佳

### 技術細節
- 修改 `src/ui/Modal.jsx` 支援遮罩控制
- 更新 `src/pages/FavoriteItem.jsx` 改善按鈕狀態和 Modal 整合
- 優化 `src/pages/FavoriteItem.css` 樣式以提升視覺呈現

### 測試項目
- [x] Modal 正常開啟和關閉
- [x] 表單為空時建立按鈕顯示正確的禁用狀態
- [x] 播放清單選單按預期不顯示背景遮罩
- [x] 表單驗證功能正常運作

### 相關問題
解決收藏片單頁面功能和樣式的設計 QA 回饋。